### PR TITLE
Fix README link with wayback machine

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ Map Github webhook events to their names
 - Using the Github webhooks / services API with AWS Lambda can be annoying because by default, AWS Lambda strips out request headers and getting them back requires a bunch of fiddly configuration (and Github webhooks pass the event type in a header).
 - `identify-github-event` identifies Github webhook events based on their payload and returns the event name
 - since `v1.1.0`: can also return the `user`, `repo` and `branch` information from a Github event (except for MembershipEvent which does not contain that information).
-- Tested on the example events [listed on the Github Events API page](https://developer.github.com/v3/activity/events/types/).
+- Tested on the example events [listed on the Github Events API page](https://web.archive.org/web/20150320055220/https://developer.github.com/v3/activity/events/types/).
 - note that Github events have unique signatures as long as you look at the full set of key names; if this ever becomes not true then some events may be confused with each other since some events share key names (but not key name signatures; e.g. difference(event.keynames, union(other.keynames)) is an empty set for some events like PublicEvent and).
 - the type key, which is not present on webhooks/services but is present on Events API calls is used if it is available (after validating it against the list of known events)
 - the NPM version filesize is quite small - it [only includes the signatures and the wrapper code](https://github.com/mixu/identify-github-event/blob/master/.npmignore)


### PR DESCRIPTION
I was confused about the context of this repo.
The docs link is redirecting to the current docs, which don't match the docs from 9 years ago.

I was considering use these sample events as test cases in another project, but I see there's a diff against the [current version's documented event types](https://docs.github.com/en/rest/using-the-rest-api/github-event-types?apiVersion=2022-11-28):

```diff
 CommitCommentEvent
 CreateEvent
 DeleteEvent
-DeploymentEvent
-DeploymentStatusEvent
 ForkEvent
 GollumEvent
 IssueCommentEvent
 IssuesEvent
 MemberEvent
-MembershipEvent
-PageBuildEvent
 PublicEvent
 PullRequestEvent
+PullRequestReviewEvent
+PullRequestReviewCommentEvent
+PullRequestReviewThreadEvent
 PushEvent
 ReleaseEvent
-RepositoryEvent
-StatusEvent
-TeamAddEvent
+SponsorshipEvent
 WatchEvent
```